### PR TITLE
Support devices needing bootanimation in System

### DIFF
--- a/prebuilt/bootanimation/bootanimation.mk
+++ b/prebuilt/bootanimation/bootanimation.mk
@@ -3,6 +3,10 @@ ifeq ($(TARGET_BOOT_ANIMATION_RES),1080)
      PRODUCT_COPY_FILES += vendor/addons/prebuilt/bootanimation/bootanimation_1080.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip
 else ifeq ($(TARGET_BOOT_ANIMATION_RES),1440)
      PRODUCT_COPY_FILES += vendor/addons/prebuilt/bootanimation/bootanimation_1440.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1080)
+     PRODUCT_COPY_FILES += vendor/addons/prebuilt/bootanimation/bootanimation_1080.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
+else ifeq ($(TARGET_PIXEL_BOOT_ANIMATION_RES),1440)
+     PRODUCT_COPY_FILES += vendor/addons/prebuilt/bootanimation/bootanimation_1440.zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip
 else
     ifeq ($(TARGET_BOOT_ANIMATION_RES),)
         $(warning "TARGET_BOOT_ANIMATION_RES is undefined, assuming 1080p")


### PR DESCRIPTION
Pixels bootanimation is better supported on system partition. If doing a dirty flash and bootanimation is not in system, Matrix animation is no longer shown and defaults to generic android animation.