### PR TITLE
addons: Build BCR if Google dialer is being built

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -370,8 +370,10 @@ PRODUCT_PACKAGES += \
     BetterQS
 
 # Basic Call Recorder
+ifeq ($(TARGET_HAS_WIFIONLY),true)
 PRODUCT_PACKAGES += \
     Bcr
+endif
 
 # StatusBarLyricExt
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
- Use same condition to build BCR as Google Dialer requires, We don't need to build if AOSP dialer is being built